### PR TITLE
Change key naming convention of hashes that we pass to head.js() function.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   bundler

--- a/lib/headjs-rails/tag_helper.rb
+++ b/lib/headjs-rails/tag_helper.rb
@@ -18,7 +18,8 @@ module Headjs
         scan(/src="([^"]+)"/).
         flatten.
         map do |src| 
-          key = 
+          cnt = 0
+          key = original_key = 
             URI.
             parse(src).
             path[%r{[^/]+\z}].
@@ -26,7 +27,7 @@ module Headjs
             gsub(/\.min$/,'').
             gsub(/-[0-9a-f]{32}$/,'')
           while keys.include?(key) do
-            key += '_' + key
+            key = "#{original_key}_#{(cnt = cnt.succ)}"
           end
           keys << key
           "{ '#{key}': '#{src}' }"

--- a/test/test_tag_helper.rb
+++ b/test/test_tag_helper.rb
@@ -34,8 +34,8 @@ module Headjs
         assert_equal "<script type=\"text/javascript\">head.js( { 'jquery': '#{jquery}' } );</script>", @helpers.headjs_include_tag(jquery)
       end
       
-      should "concatenate labels to avoid overwriting (not that great)" do
-        assert_equal "<script type=\"text/javascript\">head.js( { 'comments': '/javascripts/products/comments.js' }, { 'comments_comments': '/javascripts/reviews/comments.js' } );</script>", @helpers.headjs_include_tag('products/comments', 'reviews/comments')
+      should "increase label counter to avoid overwriting" do
+        assert_equal "<script type=\"text/javascript\">head.js( { 'comments': '/javascripts/products/comments.js' }, { 'comments_1': '/javascripts/reviews/comments.js' } );</script>", @helpers.headjs_include_tag('products/comments', 'reviews/comments')
       end
       
       should "accept strings for local paths" do


### PR DESCRIPTION
At the moment we concatenate key so it becomes unreadable for big number of duplications. In one of the projects I am working, I had like 4 classes called "base" in different namespaces. That resulted in keys like:
- base
- base_base
- base_base_base_base
- base_base_base_base_base_base_base_base

Note that it grows exponentially ;)

This commit would generate:
- base
- base1
- base2
- base3
