### PR TITLE
Fix Rails 5 deprecation warning

### DIFF
--- a/lib/headjs-rails/tag_helper.rb
+++ b/lib/headjs-rails/tag_helper.rb
@@ -3,7 +3,7 @@ module Headjs
   module TagHelper
 
     def headjs_include_tag(*sources)
-      content_tag :script, { :type => Mime::JS }, false do
+      content_tag :script, { :type => Mime[:js] }, false do
         headjs_include_js(*sources)
       end
     end


### PR DESCRIPTION
Fixes
```
DEPRECATION WARNING: Accessing mime types via constants is deprecated. Please change `Mime::JS` to `Mime[:js]`
``` 
